### PR TITLE
update branch for r-lib/actions workflows

### DIFF
--- a/.github/workflows/build-ss3-manual-html.yml
+++ b/.github/workflows/build-ss3-manual-html.yml
@@ -21,11 +21,11 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Set up R
-        uses: r-lib/actions/setup-r@master
+        uses: r-lib/actions/setup-r@v2
         with:
           r-version: 'release'
       - name: setup pandoc
-        uses: r-lib/actions/setup-pandoc@master
+        uses: r-lib/actions/setup-pandoc@v2
         with:
             pandoc-version: '2.14.0.3'
 

--- a/.github/workflows/build-ss3-warnings.yml
+++ b/.github/workflows/build-ss3-warnings.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: setup R
-        uses: r-lib/actions/setup-r@master
+        uses: r-lib/actions/setup-r@v2
 
       - name: Get admb and put in path, linux
         run: |

--- a/.github/workflows/check-ss3-models-run.yml
+++ b/.github/workflows/check-ss3-models-run.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
           
       - name: setup R  
-        uses: r-lib/actions/setup-r@master
+        uses: r-lib/actions/setup-r@v2
         
       - name: Get the 3.30.18 SS3 executable
         run:  wget -O ss https://github.com/nmfs-stock-synthesis/stock-synthesis/releases/download/v3.30.18/ss_linux

--- a/.github/workflows/deploy-ss3-docs.yml
+++ b/.github/workflows/deploy-ss3-docs.yml
@@ -14,11 +14,11 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up R
-        uses: r-lib/actions/setup-r@master
+        uses: r-lib/actions/setup-r@v2
         with:
           r-version: 'release'
       - name: setup pandoc
-        uses: r-lib/actions/setup-pandoc@master
+        uses: r-lib/actions/setup-pandoc@v2
         with:
             pandoc-version: '2.14.0.3'
 

--- a/.github/workflows/r4ss-extra-tests.yml
+++ b/.github/workflows/r4ss-extra-tests.yml
@@ -29,11 +29,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
 
-      - uses: r-lib/actions/setup-pandoc@master
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - name: Query dependencies
         run: |

--- a/.github/workflows/run-ss3-mcmc.yml
+++ b/.github/workflows/run-ss3-mcmc.yml
@@ -24,7 +24,7 @@ jobs:
           path: test-models-repo
 
       - name: setup R
-        uses: r-lib/actions/setup-r@master
+        uses: r-lib/actions/setup-r@v2
 
       - name: Get admb and put in path, linux
         run: |

--- a/.github/workflows/run-ss3-no-est.yml
+++ b/.github/workflows/run-ss3-no-est.yml
@@ -31,7 +31,7 @@ jobs:
           path: test-models-repo
 
       - name: setup R
-        uses: r-lib/actions/setup-r@master
+        uses: r-lib/actions/setup-r@v2
 
       - name: Get admb and put in path, linux
         run: |

--- a/.github/workflows/run-ss3-with-est.yml
+++ b/.github/workflows/run-ss3-with-est.yml
@@ -22,7 +22,7 @@ jobs:
           path: test-models-repo
 
       - name: setup R
-        uses: r-lib/actions/setup-r@master
+        uses: r-lib/actions/setup-r@v2
 
       - name: Get admb and put in path, linux
         run: |

--- a/.github/workflows/test-r4ss-with-ss3.yml
+++ b/.github/workflows/test-r4ss-with-ss3.yml
@@ -24,7 +24,7 @@ jobs:
           path: test-models-repo
 
       - name: setup R
-        uses: r-lib/actions/setup-r@master
+        uses: r-lib/actions/setup-r@v2
 
       - name: install dependencies
         run: Rscript -e 'install.packages("remotes")'


### PR DESCRIPTION
Workflow failed with "Error: Unable to resolve action `r-lib/actions@master`, unable to find version `master`":
https://github.com/r4ss/r4ss/actions/runs/3337418934/jobs/5523736468.

Looking at https://github.com/r-lib/actions/, the "master" branch has been removed and guidance at https://github.com/r-lib/actions/issues/639 suggests switching to "v2".