### PR TITLE
update actions/checkout from v2 to v3

### DIFF
--- a/.github/workflows/build-ss3-manual-html.yml
+++ b/.github/workflows/build-ss3-manual-html.yml
@@ -16,7 +16,7 @@ jobs:
       RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
     steps:
       - name: Set up Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
 

--- a/.github/workflows/build-ss3-manual-pdf.yml
+++ b/.github/workflows/build-ss3-manual-pdf.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     
       - name: Set up Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with: 
           ref: ${{ inputs.ref }}
         

--- a/.github/workflows/build-ss3-warnings.yml
+++ b/.github/workflows/build-ss3-warnings.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
 
       - name: Checkout ss repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: setup R
         uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -27,7 +27,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get admb and put in path, windows
         if: matrix.config.os == 'windows-latest'
@@ -38,7 +38,7 @@ jobs:
 
       - name: checkout admb, mac
         if: matrix.config.os == 'macos-latest'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: admb-project/admb
           path: admb

--- a/.github/workflows/check-ss3-models-run.yml
+++ b/.github/workflows/check-ss3-models-run.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
           
       - name: setup R  
         uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/deploy-ss3-docs.yml
+++ b/.github/workflows/deploy-ss3-docs.yml
@@ -11,7 +11,7 @@ jobs:
       RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
     steps:
       - name: Set up Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up R
         uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/r4ss-extra-tests.yml
+++ b/.github/workflows/r4ss-extra-tests.yml
@@ -27,7 +27,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -65,7 +65,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Get repository of SS models
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'nmfs-stock-synthesis/test-models'
           path: test-models-repo

--- a/.github/workflows/run-ss3-mcmc.yml
+++ b/.github/workflows/run-ss3-mcmc.yml
@@ -14,11 +14,11 @@ jobs:
     steps:
 
       - name: Checkout ss repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
 
       - name: Checkout models repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'nmfs-stock-synthesis/test-models'
           path: test-models-repo

--- a/.github/workflows/run-ss3-no-est.yml
+++ b/.github/workflows/run-ss3-no-est.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
 
       - name: Checkout ss repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
  #     - name: Get last compiled version of SS; alternative to compiling in same wkflow
  #       uses: dawidd6/action-download-artifact@v2
@@ -25,7 +25,7 @@ jobs:
  #         path: ss_linux
 
       - name: Checkout models repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'nmfs-stock-synthesis/test-models'
           path: test-models-repo

--- a/.github/workflows/run-ss3-with-est.yml
+++ b/.github/workflows/run-ss3-with-est.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
 
       - name: Checkout ss repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Checkout models repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'nmfs-stock-synthesis/test-models'
           path: test-models-repo

--- a/.github/workflows/test-r4ss-with-ss3.yml
+++ b/.github/workflows/test-r4ss-with-ss3.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
 
       - name: Checkout ss repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Checkout models repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'nmfs-stock-synthesis/test-models'
           path: test-models-repo

--- a/.github/workflows/update-ss3-version.yml
+++ b/.github/workflows/update-ss3-version.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get the latest stock synthesis binaries
         run: |


### PR DESCRIPTION
@k-doering-NOAA, thanks for the quick response to the previous PR.

I see that `ghactions4r` also updated `actions/checkout@v2` to `actions/checkout@v3` inhttps://github.com/nmfs-fish-tools/ghactions4r/commit/1aefda81ab31974c4cee7212dca7886bad89cd03, so this repeats that change for this repo.