### PR TITLE
fix: install libcurl

### DIFF
--- a/.github/workflows/test-r4ss-with-ss3.yml
+++ b/.github/workflows/test-r4ss-with-ss3.yml
@@ -23,6 +23,9 @@ jobs:
           repository: 'nmfs-stock-synthesis/test-models'
           path: test-models-repo
 
+      - name: install libcurl
+        run: sudo apt-get install -y libcurl4-openssl-dev
+
       - name: setup R
         uses: r-lib/actions/setup-r@v2
 


### PR DESCRIPTION
Needed by r pkg curl. Perhaps because of
switch to ubuntu 22 instead of 20?