### PR TITLE
Add sudo update step to libcurl

### DIFF
--- a/.github/workflows/test-r4ss-with-ss3.yml
+++ b/.github/workflows/test-r4ss-with-ss3.yml
@@ -24,7 +24,9 @@ jobs:
           path: test-models-repo
 
       - name: install libcurl
-        run: sudo apt-get install -y libcurl4-openssl-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev
 
       - name: setup R
         uses: r-lib/actions/setup-r@v2


### PR DESCRIPTION
Was getting an error on the libcurl step [here](https://github.com/nmfs-stock-synthesis/stock-synthesis/actions/runs/3893912378) and so discovered that you have to add the update step for the most recent version of ubuntu.