### PR TITLE
Build ss3 r version change

### DIFF
--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -80,8 +80,8 @@ jobs:
       
       - name: Set up R
         uses: r-lib/actions/setup-r@v2
-          with:
-            r-version: '4.2.3'
+        with:
+          r-version: '4.2.3'
           
       - name: get info on gcc version and path
         if: matrix.config.os == 'windows-latest'

--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -80,6 +80,8 @@ jobs:
       
       - name: Set up R
         uses: r-lib/actions/setup-r@v2
+          with:
+            r-version: '4.2.3'
           
       - name: get info on gcc version and path
         if: matrix.config.os == 'windows-latest'
@@ -203,7 +205,6 @@ jobs:
       - name: Build stock synthesis for windows
         if: matrix.config.os == 'windows-latest'
         run: |
-          
           cd Compile
           ./Make_SS_safe.bat
           ./Make_SS_fast.bat


### PR DESCRIPTION
Specify r version to the earlier version as the latest version used RTools43 which creates issues building SS3 for windows. This issue will be need to be solved at a later date (and has been entered as an admb issue [here](https://github.com/admb-project/admb/issues/285) but for now the version will be reverted to allow SS3 pull requests to be merged.